### PR TITLE
add Node Security Platform (NSP) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: node_js
+node_js:
+  - '0.10'
+  - '4.4'
+sudo: false
+before_install:
+  - npm install -g nsp
+install: npm install
+services:
+  - docker
+script:
+  - nsp check
+  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+notifications:
+  email: false
+  slack:
+    on_success: change
+    on_failure: always
+    rooms:
+      secure: >-
+        GAbfKChjxJxjOI3Kjrw/n20InJQC1z+MvlbD7lXXOGSqYBIEldDdXCKCYoVSFTGF+OCsik4Sb8Oj7acSVD1XlU1xQI63zOig7q9Kdb32lqBy69mr5xMdsruvklb8CuA8bMbgE7zKzq74UhcAhPr4A9dp2mQj0NJr2SEGIkqDLiWq8kjuvsKci8KdyTrbKd3Am1Mf/unCzoSFw4CNHIl4AA08yPG5gjQaQ8aKVChvwmDYHTgTlqPgg5DAAOX1lwjTVVDNuQHg5OHxeuXpgxrDQZVy2gP6VdInHg1Gexovk0/n8rnAmhDJsc5TR4dzM8t96N2iuG47v4K71Wln7PoKhF7/5gwJEEiYSKlbXSo9ywLEmqQFekB94p7WALjnqbEMK+OQWy6kOuAMMmNShHwd1gwvVma459yrzsLqnp0lBTF0kypjTbxeUQXvAZhsqBeDIqHAi2fwujePUt47Jo4GG52jrxi4fWjh6Usc4nvz+tCTjgHVYAcYbVqPC8YK8GQEiCV2FfDMw9a3FJV/7/uh4080nTaL/OaXKXIaNKTHoWlZV9UFZCU5qnRs/x0I8EnJDSqNamViIsPkow7WKIdw2/lz8yD4AIfM1NbMgEQdpea4PVHBB/ldOalr96MbWiAG/FwSBFF4QbNgC0lBUtloSPRhiruQvzFM/EQsMWITzu0=
+    on_pull_requests: false
+


### PR DESCRIPTION
Motivation:
To help identify/discover known vulnerabilities in this project.

Modifications:
Added nsp to the CI configuration (Travis).

Result:
nsp check will be run as part of CI

JIRA:
https://issues.jboss.org/browse/RAINCATCH-226
