### PR TITLE
remove travis nsp checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ node_js:
   - '0.10'
   - '4.4'
 sudo: false
-before_install:
-  - npm install -g nsp
 install: npm install
 services:
   - docker
 script:
-  - nsp check
   - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install: npm install
 services:
   - docker
 script:
-  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 notifications:
   email: false
   slack:


### PR DESCRIPTION
**Motivation**
NSP was obsoleted by using snyk for checking vulnerabilities in dependencies. Currently the hack done for it to be an 'optional' check i.e. not fail builds is actually making CI builds that are supposed to fail pass.